### PR TITLE
fix: Convert date to interger before adding integer to it

### DIFF
--- a/lib/nethttputils.rb
+++ b/lib/nethttputils.rb
@@ -215,7 +215,7 @@ module NetHTTPUtils
             elsif response.key? "x-ratelimit-remaining"
               [
                 response.fetch("x-ratelimit-remaining").to_i,
-                now + response.fetch("x-ratelimit-reset").to_i,
+                now.to_i + response.fetch("x-ratelimit-reset").to_i,
                 now.to_i,
               ]
             end

--- a/nethttputils.gemspec
+++ b/nethttputils.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name         = "nethttputils"
-  spec.version      = "0.4.4.0"
+  spec.version      = "0.4.4.1"
   spec.summary      = "this tool is like a pet that I adopted young and now I depend on, sorry"
   spec.description = <<-EOF
     Back in 2015 I was a guy automating things at my job and two scripts had a common need --


### PR DESCRIPTION
@Nakilon  - variable "now" is a timestamp and when you add to it, it remains a timestamp. Then later .fdiv is called on the timestamp which causes a crash

```
(Time.now + 1000).fdiv(1)
NoMethodError (undefined method `fdiv' for 2023-05-13 11:12:09.8725 -0400:Time)
```

Not really sure how this worked before